### PR TITLE
Release v2.16.1

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "WEPPY AI Agent Plugin marketplace for Codex — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit",
-    "version": "2.16.0"
+    "version": "2.16.1"
   },
   "plugins": [
     {
@@ -20,7 +20,7 @@
       },
       "category": "Coding",
       "description": "WEPPY AI Agent Plugin for Codex.",
-      "version": "2.16.0"
+      "version": "2.16.1"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "WEPPY AI Agent Plugin marketplace for Claude Code — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit",
-    "version": "2.16.0"
+    "version": "2.16.1"
   },
   "plugins": [
     {
       "name": "weppy-roblox-ai-toolkit",
       "source": "./plugins/weppy-roblox-mcp",
       "description": "WEPPY AI Agent Plugin for Claude Code — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit.",
-      "version": "2.16.0",
+      "version": "2.16.1",
       "author": {
         "name": "hope1026"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,17 @@ All notable changes to this project will be documented in this file.
 
 
 
+
+## [2.16.1] - 2026-08-29
+
+### Features
+
+- **Review Dashboard records without losing the list** — Playtest history now uses the full content area instead of reserving an empty report panel, and Playtest, Tools History, and UI Studio open record details in the same focused dialog. You can compare more runs at once, inspect the full evidence or routing details, then return to the same list position and filters.
+
+### Bug Fixes
+
+- **Show the correct Playtest outcome and newest runs first** — Structured Playtest history now keeps passed, failed, timed out, cancelled, and insufficient-evidence results distinct, and sorts legacy and structured timestamps by their actual time instead of their text format.
+
 ## [2.16.0] - 2026-08-29
 
 ### Features

--- a/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "weppy-roblox-ai-toolkit",
   "description": "WEPPY AI Agent Plugin for Claude Code.",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "author": {
     "name": "hope1026"
   },

--- a/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "weppy-roblox-ai-toolkit",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "description": "WEPPY AI Agent Plugin for Codex.",
   "author": {
     "name": "hope1026"


### PR DESCRIPTION
## Release v2.16.1


### Features

- **Review Dashboard records without losing the list** — Playtest history now uses the full content area instead of reserving an empty report panel, and Playtest, Tools History, and UI Studio open record details in the same focused dialog. You can compare more runs at once, inspect the full evidence or routing details, then return to the same list position and filters.

### Bug Fixes

- **Show the correct Playtest outcome and newest runs first** — Structured Playtest history now keeps passed, failed, timed out, cancelled, and insufficient-evidence results distinct, and sorts legacy and structured timestamps by their actual time instead of their text format.

---
Automated release from weppy-roblox-mcp-private